### PR TITLE
Fix output when input contains non-ascii character

### DIFF
--- a/rst2html.py
+++ b/rst2html.py
@@ -36,4 +36,4 @@ def main():
     return transform(writer=Writer(), part='html_body')
 
 if __name__ == '__main__':
-    print(main())
+    print(main().encode('utf-8'))


### PR DESCRIPTION
main() returns a unicode object, and print has to encode this for output.  When output to terminal this usually works (because your terminal is unicode), but when output is to a file print defaults to ascii.

When I have a source file with a £ in it, I would previously get:
  File "plugins/jekyll-rst/rst2html.py", line 39, in <module>
    print(main())
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa3' in position 1246: ordinal not in range(128)

With this change it works cleanly, albeit hard coded for utf-8.
